### PR TITLE
Fix shebang

### DIFF
--- a/haxcs
+++ b/haxcs
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#! /usr/bin/env bash
 
 python src/main.py
 


### PR DESCRIPTION
When running with fish, shebang needs to be corrected or bash will not be called. 